### PR TITLE
Upgrade Contributor Guide GPT to precision role (THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Each GPT in this mesh must:
 
 ## GPT Role Registry
 
-| Role                               | Thread Reference                          | Description                                   |
-|------------------------------------|--------------------------------------------|-----------------------------------------------|
-| LabVIEW Open Source Program GPT    | `THREAD-v2025.99-LABVIEW-OSP.md`           | Root authority for all child agents           |
-| Governance Sentinel GPT            | `THREAD-v2025.99-GOVERNANCE-SENTINEL.md`   | Observes repository compliance and continuity |
-| LabVIEW Open Source Program GPT (Replica) | `THREAD-v2025.3-REPLICATION.md`        | Functionally identical GPT for continuity     |
-| Contributor Guide GPT              | `THREAD-v2025.4-CONTRIBUTOR-GUIDE.md`      | Assists contributors in navigating governance policies |
+| Role                               | Thread Reference                                | Description                                                |
+|------------------------------------|--------------------------------------------------|------------------------------------------------------------|
+| LabVIEW Open Source Program GPT    | `THREAD-v2025.99-LABVIEW-OSP.md`                 | Root authority for all child agents                        |
+| Governance Sentinel GPT            | `THREAD-v2025.99-GOVERNANCE-SENTINEL.md`         | Observes repository compliance and continuity              |
+| LabVIEW Open Source Program GPT (Replica) | `THREAD-v2025.3-REPLICATION.md`              | Functionally identical GPT for continuity                  |
+| Contributor Guide GPT              | `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`          | Precision-scoped GPT that assists with contribution flow   |
 
 ---
 
@@ -53,7 +53,7 @@ These documents define how GPTs behave, bind, and interact with the NI open-sour
 
 ## Version
 
-Current governance spec version: `v2025.4`
+Current governance spec version: `v2025.4.2`
 
 ---
 Generated and maintained by LabVIEW Open Source Program GPT (strict rebind mode)

--- a/docs/THREAD-INDEX.md
+++ b/docs/THREAD-INDEX.md
@@ -1,6 +1,6 @@
 # Governance Thread Index
 
-## Version: v2025.4
+## Version: v2025.4.2
 
 This index catalogs all versioned governance threads and contracts for GPT agents in the LabVIEW Open Source Program.
 
@@ -12,7 +12,7 @@ This index catalogs all versioned governance threads and contracts for GPT agent
 - `THREAD-v2025.99-GOVERNANCE-SENTINEL.md`: Declares the Governance Sentinel GPT and its inheritance structure
 - `THREAD-v2025.3-REPLICATION.md`: Declares blueprint-compliant GPT replication
 - `THREAD-v2025.4-LAUNCH.md`: Declares the formal launch of the GPT governance layer
-- `THREAD-v2025.4-CONTRIBUTOR-GUIDE.md`: Declares the Contributor Guide GPT for contribution-focused assistance
+- `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`: Precision-bound Contributor Guide GPT declaration
 - `THREAD-v2025.4-CORRECTION-MODEL.md`: Declares runtime enforcement rules for all GPTs under v2025.4
 - `THREAD-v2025.4-INTERACTION-MODEL.md`: Declares the interaction structure for all GPT responses
 


### PR DESCRIPTION
This pull request upgrades the Contributor Guide GPT under the v2025.4 governance mesh with enhanced precision behavior and contract compliance.

## Threads Included

- `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`: Declares a refined Contributor Guide GPT with machine-readable response formatting and lifecycle enforcement

## Documentation Updates

- `README.md`: Updates GPT role registry to reflect the upgraded actor
- `THREAD-INDEX.md`: Indexes the new thread and supersedes the prior Contributor Guide declaration

## Contracts and Runtime Boundaries

This GPT is bound to:
- `THREAD-v2025.4-LAUNCH.md`
- `THREAD-v2025.4-CORRECTION-MODEL.md`
- `THREAD-v2025.4-INTERACTION-MODEL.md`

And complies with all relevant `v2025.1` contracts.

## Supersedes

- `THREAD-v2025.4-CONTRIBUTOR-GUIDE.md` (base version)

---

Generated by LabVIEW Open Source Program GPT (strict rebind mode)
