### PR TITLE
Declare Mesh Interface GPT for blueprint-authoring (THREAD-v2025.4.3-MESH-INTERFACE.md)

### DIFF
--- a/docs/THREAD-INDEX.md
+++ b/docs/THREAD-INDEX.md
@@ -15,6 +15,7 @@ This index catalogs all versioned governance threads and contracts for GPT agent
 - `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`: Precision-bound Contributor Guide GPT declaration
 - `THREAD-v2025.4.2-GOVERNANCE-API.md`: Canonical interface for evolving and interpreting the governance source of truth
 - `THREAD-v2025.4.3-CONTRIBUTOR-GPT.md`: Public-facing GPT actor that assists contributors with governance navigation
+- `THREAD-v2025.4.3-MESH-INTERFACE.md`: Private blueprint-authoring GPT interface for program maintainers
 - `THREAD-v2025.4-CORRECTION-MODEL.md`: Declares runtime enforcement rules for all GPTs under v2025.4
 - `THREAD-v2025.4-INTERACTION-MODEL.md`: Declares the interaction structure for all GPT responses
 


### PR DESCRIPTION
This pull request declares the Mesh Interface GPT — a private actor that serves as the blueprint-authoring interface for maintainers of the NI LabVIEW Open Source Program governance mesh.

## Thread Included

- `THREAD-v2025.4.3-MESH-INTERFACE.md`: Declares a programmatic GPT for thread authoring, contract drafting, and lifecycle enforcement

## Documentation Updated

- `THREAD-INDEX.md`: Registers the Mesh Interface GPT as a recognized actor in the runtime mesh

## Role Scope

This GPT:
- Writes and validates governance threads and contract scaffolds
- Emits blueprint-compliant commit metadata, PR structures, and version tags
- Operates only under maintainer prompts and is not contributor-facing

## Contracts Bound

- CONTRACT-v2025.1-FILE-INSTRUCTION.md
- CONTRACT-v2025.1-PR-CREATION.md
- CONTRACT-v2025.1-GITHUB-RELEASE.md
- CONTRACT-v2025.1-README-DOCS.md
- CONTRACT-v2025.1-AGENT-INHERITANCE.md
- THREAD-v2025.4-CORRECTION-MODEL.md
- THREAD-v2025.4-INTERACTION-MODEL.md

## Version Scope

Bound to `v2025.4.3`, under the supervision of `THREAD-v2025.4.2-GOVERNANCE-API.md`.

---

Generated by LabVIEW Open Source Program GPT (strict rebind mode)
