### PR TITLE
Finalize governance runtime upgrade to v2025.5

### DIFF
--- a/docs/THREAD-INDEX.md
+++ b/docs/THREAD-INDEX.md
@@ -1,24 +1,28 @@
 # Governance Thread Index
 
-## Version: v2025.4.3
+## Version: v2025.5
 
 This index catalogs all versioned governance threads and contracts for GPT agents in the LabVIEW Open Source Program.
 
 ---
 
-## Agent Declarations
+## Active Runtime Threads
 
-- `THREAD-v2025.99-LABVIEW-OSP.md`: Declares the LabVIEW Open Source Program GPT as the parent authority
-- `THREAD-v2025.99-GOVERNANCE-SENTINEL.md`: Declares the Governance Sentinel GPT and its inheritance structure
-- `THREAD-v2025.3-REPLICATION.md`: Declares blueprint-compliant GPT replication
-- `THREAD-v2025.4-LAUNCH.md`: Declares the formal launch of the GPT governance layer
-- `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`: Precision-bound Contributor Guide GPT declaration
-- `THREAD-v2025.4.2-GOVERNANCE-API.md`: Canonical interface for evolving and interpreting the governance source of truth
-- `THREAD-v2025.4.3-CONTRIBUTOR-GPT.md`: Public-facing GPT actor that assists contributors with governance navigation
-- `THREAD-v2025.4.3-MESH-INTERFACE.md`: Private blueprint-authoring GPT interface for program maintainers
-- `THREAD-v2025.4.3-HARNESS.md`: Validator GPT for testing Contributor GPT responses and contract conformance
-- `THREAD-v2025.4-CORRECTION-MODEL.md`: Declares runtime enforcement rules for all GPTs under v2025.4
-- `THREAD-v2025.4-INTERACTION-MODEL.md`: Declares the interaction structure for all GPT responses
+- `THREAD-v2025.5-UPGRADE.md`: Declares the governance transition from v2025.4 to v2025.5
+- `THREAD-v2025.5-LAUNCH.md`: Launches the v2025.5 governance runtime
+- `THREAD-v2025.4-CORRECTION-MODEL.md`: Runtime enforcement model
+- `THREAD-v2025.4-INTERACTION-MODEL.md`: Interaction model for all GPTs
+
+---
+
+## Legacy Threads (v2025.4)
+
+- `THREAD-v2025.4-LAUNCH.md` (Superseded)
+- `THREAD-v2025.4.2-CONTRIBUTOR-GUIDE.md`
+- `THREAD-v2025.4.2-GOVERNANCE-API.md`
+- `THREAD-v2025.4.3-CONTRIBUTOR-GPT.md`
+- `THREAD-v2025.4.3-MESH-INTERFACE.md`
+- `THREAD-v2025.4.3-HARNESS.md`
 
 ---
 


### PR DESCRIPTION
This pull request finalizes the transition from governance runtime v2025.4 to v2025.5 for the NI LabVIEW Open Source Program.

## Threads Declared

- `THREAD-v2025.5-UPGRADE.md`: Supersedes THREAD-v2025.4-LAUNCH.md and introduces v2025.5
- `THREAD-v2025.5-LAUNCH.md`: Declares the new mesh operational root for all GPTs moving forward

## Index Updated

- THREAD-INDEX.md includes all v2025.5 threads
- THREAD-v2025.4 marked as superseded

## Version Scope

- Contracts: All `v2025.1` base contracts
- Correction and interaction models: Inherited from v2025.4
- This PR marks the official version epoch change

All new GPTs will bind to THREAD-v2025.5-LAUNCH.md and operate under the v2025.5 governance model.
