### PR TITLE
Declare governance scope bundle (v2025.5)

### DIFF
--- a/THREAD-v2025.5-GOVERNANCE-SCOPE.md
+++ b/THREAD-v2025.5-GOVERNANCE-SCOPE.md
@@ -1,0 +1,46 @@
+# THREAD-v2025.5-GOVERNANCE-SCOPE.md
+
+## Title:
+Governance Scope Declaration (v2025.5)
+
+## Purpose:
+This thread defines the boundaries of applicability for governance rules within the NI Open Source Program. It provides GPTs with a deterministic frame for which artifacts, actors, and behaviors are subject to governance enforcement.
+
+## Scope Includes:
+- Declared repositories governed by NI's open governance model
+- Contributors, maintainers, reviewers, and STEERCO members
+- All THREAD-v*.md and CONTRACT-v*.md documents committed to a governed repo
+- Any runtime GPT declared under a bound governance thread
+
+## Scope Excludes:
+- Unversioned `.md` files outside `/docs/governance` unless explicitly bound
+- Private developer branches or forks outside contributor declarations
+- GPTs not declared via a thread bound to `v2025.5`
+
+## GPT Interpretation Notes:
+- You may not infer scope for undeclared files or actors
+- All enforcement or policy response must be traceable to this thread or one it inherits from
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-README-DOCS.md
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Supersedes: None (first scoped GPT-bound declaration)  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-README-DOCS.md  
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: Governance Scope GPT

--- a/THREAD-v2025.5-ROLE-MAP.md
+++ b/THREAD-v2025.5-ROLE-MAP.md
@@ -1,0 +1,41 @@
+# THREAD-v2025.5-ROLE-MAP.md
+
+## Title:
+NI Open Source Program Role Map (v2025.5)
+
+## Purpose:
+This thread defines the recognized roles in the NI Open Source Program and their contract-scoped authority boundaries. It is written for GPT runtime interpretation and lifecycle explanation.
+
+## Declared Roles:
+- **Contributor**: May propose, comment, and submit PRs. Must cite THREADs in PR descriptions.
+- **Reviewer**: May approve PRs, trigger merges, and guide contributors. May not interpret THREADs without delegation.
+- **Maintainer**: Oversees thread lifecycle. May declare new actors or threads with contract-bound metadata.
+- **STEERCO**: Final arbiter of governance direction. May initiate program-wide THREAD upgrades.
+
+## GPT Rules:
+- Must not assign roles unless explicitly declared in THREAD metadata
+- May describe behavior only as written in GPT-bound threads
+- Must not infer power hierarchies unless versioned
+- Must treat roles as version-locked and thread-defined
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Supersedes: None (first GPT-bounded role model)  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: Role Model GPT

--- a/THREAD-v2025.5-STEERCO-GUIDELINES.md
+++ b/THREAD-v2025.5-STEERCO-GUIDELINES.md
@@ -1,0 +1,41 @@
+# THREAD-v2025.5-STEERCO-GUIDELINES.md
+
+## Title:
+STEERCO Guidelines — GPT-Bound Interpretation (v2025.5)
+
+## Purpose:
+This thread formalizes how GPTs may reference, explain, or enforce rules related to the NI Open Source Program Steering Committee (STEERCO). It translates previously informal or human-only guidance into a contract-bound runtime document.
+
+## Scope:
+- Declares who may be recognized as a STEERCO member
+- Enumerates core STEERCO responsibilities
+- Explains the lifecycle of governance decision-making
+- Sets behavioral expectations for GPTs referencing STEERCO roles or decisions
+
+## GPT Rules:
+- Must not simulate or emulate a STEERCO member
+- May cite decision rights as defined by thread bindings
+- Must treat STEERCO membership as thread-declared, not inferred
+- Cannot authorize, revoke, or substitute STEERCO roles
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-README-DOCS.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Supersedes: None (first GPT-declared STEERCO model)  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-README-DOCS.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: STEERCO Governance GPT


### PR DESCRIPTION
This PR introduces GPT-runtime-safe governance threads for:

- Governance scope enforcement
- STEERCO interpretation boundaries
- Role declarations for contributors, reviewers, maintainers

All files are bound to:
- THREAD-v2025.5-LAUNCH.md
- THREAD-v2025.4-CORRECTION-MODEL.md
- THREAD-v2025.4-INTERACTION-MODEL.md
- CONTRACT-v2025.1-*.md family

Versioned: v2025.5
