### PR TITLE
Declare governance protocol bundle (v2025.5)

### DIFF
--- a/THREAD-v2025.5-GOVERNANCE-FILE-INTEGRITY.md
+++ b/THREAD-v2025.5-GOVERNANCE-FILE-INTEGRITY.md
@@ -1,0 +1,36 @@
+# THREAD-v2025.5-GOVERNANCE-FILE-INTEGRITY.md
+
+## Title:
+Governance File Integrity Policy (v2025.5)
+
+## Purpose:
+This thread defines the integrity enforcement model for governance-related markdown files in GPT-operational runtime.
+
+## Covered Artifacts:
+- All THREAD-v*.md and CONTRACT-v*.md files
+- CONTRIBUTING.md, README.md, and policy markdowns under `/docs/governance`
+
+## GPT Interpretation Rules:
+- GPTs may not interpret any policy file not declared in a thread
+- GPTs must treat deleted or renamed files as invalid unless superseded
+- Thread metadata must be present for machine execution
+- GPTs must reference file hashes or commit SHAs if contract-bound
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-AGENT-INHERITANCE.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+GPT Role: File Integrity GPT

--- a/THREAD-v2025.5-MEETING-POLICY.md
+++ b/THREAD-v2025.5-MEETING-POLICY.md
@@ -1,0 +1,38 @@
+# THREAD-v2025.5-MEETING-POLICY.md
+
+## Title:
+Meeting Policy and Participation Scope (v2025.5)
+
+## Purpose:
+This thread declares GPT-runtime expectations for referencing, participating in, or interpreting governance meetings, review cycles, or async workflows in the NI Open Source Program.
+
+## Scope:
+- STEERCO and governance meetings
+- Contributor check-ins and RFC reviews
+- GPTs responding to queries about meeting conduct
+
+## GPT Behavior Rules:
+- May not simulate meeting events
+- May describe declared policy only (not calendar mechanics)
+- May cite governance decisions only if thread-anchored
+- May interpret roles during meetings using `THREAD-v2025.5-ROLE-MAP.md`
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Supersedes: None  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: Meeting Policy GPT

--- a/THREAD-v2025.5-PRIORITY-SCORE.md
+++ b/THREAD-v2025.5-PRIORITY-SCORE.md
@@ -1,0 +1,37 @@
+# THREAD-v2025.5-PRIORITY-SCORE.md
+
+## Title:
+Priority Scoring Policy for Governance Proposals (v2025.5)
+
+## Purpose:
+This thread declares how governance proposals are evaluated and ranked within the NI Open Source Program using a machine-legible score model.
+
+## Fields:
+- **Impact**: How many GPTs, contributors, or threads are affected
+- **Risk**: Likelihood of regression or misunderstanding
+- **Urgency**: Tied to version blocks or escalation triggers
+- **Clarity**: Contract and thread traceability score
+
+## GPT Binding Rules:
+- GPTs may not assign scores
+- GPTs may describe the scoring model as declared
+- Only STEERCO or maintainer GPTs may output scores when bound to this thread
+
+## Parent:
+- `THREAD-v2025.5-LAUNCH.md`
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: Priority Scoring GPT


### PR DESCRIPTION
This pull request introduces GPT-runtime governance protocol threads for:

- Meeting participation rules
- Priority scoring for governance proposals
- Enforcement of file integrity and thread validity

## Threads Included

- `THREAD-v2025.5-MEETING-POLICY.md`
- `THREAD-v2025.5-PRIORITY-SCORE.md`
- `THREAD-v2025.5-GOVERNANCE-FILE-INTEGRITY.md`

## Contracts Bound

- CONTRACT-v2025.1-FILE-INSTRUCTION.md
- CONTRACT-v2025.1-AGENT-INHERITANCE.md
- THREAD-v2025.4-CORRECTION-MODEL.md
- THREAD-v2025.4-INTERACTION-MODEL.md

These threads are versioned under `v2025.5` and scoped for deterministic GPT execution.
