### PR TITLE
Declare engagement UX bundle (v2025.5)

### DIFF
--- a/THREAD-v2025.5-CONTRIBUTING.md
+++ b/THREAD-v2025.5-CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# THREAD-v2025.5-CONTRIBUTING.md
+
+## Title:
+Contributor Guide and Participation Boundaries (v2025.5)
+
+## Purpose:
+This thread binds the human-facing CONTRIBUTING.md to a GPT-safe contract structure. It describes contributor expectations, PR behavior, discussion etiquette, and governance alignment.
+
+## Contributor Expectations:
+- Propose changes through issues or PRs
+- Reference THREAD-v*.md when governance is impacted
+- Submit changes on feature branches with clear lifecycle metadata
+- Respond to review feedback respectfully and asynchronously
+
+## GPT Behavior:
+- May explain contributor expectations based on this thread
+- Must not simulate contributors
+- Must not infer undocumented exceptions to contribution policy
+- May explain how `CONTRIBUTING.md` maps to THREAD and CONTRACTs
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-README-DOCS.md
+- THREAD-v2025.4-CORRECTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-README-DOCS.md  
+- THREAD-v2025.4-CORRECTION-MODEL.md  
+GPT Role: Contributor Policy GPT

--- a/THREAD-v2025.5-ENGAGEMENT-GUIDE.md
+++ b/THREAD-v2025.5-ENGAGEMENT-GUIDE.md
@@ -1,0 +1,35 @@
+# THREAD-v2025.5-ENGAGEMENT-GUIDE.md
+
+## Title:
+Contributor Engagement and Issue Policy (v2025.5)
+
+## Purpose:
+This thread formalizes GPT-readable policy for contributor engagement, issue creation, feedback channels, and proposal discussion under the NI Open Source Program.
+
+## Engagement Modes:
+- Opening issues or discussions with declared intent
+- Responding to feedback as a contributor or maintainer
+- Suggesting new governance behavior within THREAD-scoped policy
+- Requesting clarification through contributor-facing GPTs
+
+## GPT Responsibilities:
+- Must not simulate humans
+- May explain expectations from this thread
+- Must cite this thread when referencing engagement policy
+- May not infer issue priority or status without a bound THREAD
+
+## Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md
+- CONTRACT-v2025.1-README-DOCS.md
+- THREAD-v2025.4-INTERACTION-MODEL.md
+
+## Commit:
+NI Open Source Program — 2025
+
+---
+Version: v2025.5  
+Contracts:
+- CONTRACT-v2025.1-FILE-INSTRUCTION.md  
+- CONTRACT-v2025.1-README-DOCS.md  
+- THREAD-v2025.4-INTERACTION-MODEL.md  
+GPT Role: Engagement Guide GPT


### PR DESCRIPTION
This pull request introduces GPT-runtime engagement threads for:

- Contributor participation expectations
- Feedback, proposal, and PR etiquette
- Contract-safe mapping of CONTRIBUTING.md to THREAD-v*.md

## Threads Included

- `THREAD-v2025.5-ENGAGEMENT-GUIDE.md`
- `THREAD-v2025.5-CONTRIBUTING.md`

## Contracts Bound

- CONTRACT-v2025.1-FILE-INSTRUCTION.md
- CONTRACT-v2025.1-README-DOCS.md
- THREAD-v2025.4-CORRECTION-MODEL.md
- THREAD-v2025.4-INTERACTION-MODEL.md

All threads are versioned `v2025.5` and scoped for safe GPT explanation of contributor behavior.
